### PR TITLE
tests no longer rely on `python3` symlink being present

### DIFF
--- a/hb_downloader/test/test_parse_cmdline.py
+++ b/hb_downloader/test/test_parse_cmdline.py
@@ -11,11 +11,11 @@ actions = ["download", "list"]
 
 def test_help():
     # Check that the script runs and displays the help text without errors
-    subprocess.check_output(["python3", "hb-downloader.py", "-h"])
+    subprocess.check_output([sys.executable, "hb-downloader.py", "-h"])
 
     # Check the same with basic actions
     for a in actions:
-        subprocess.check_output(["python3", "hb-downloader.py", a, "-h"])
+        subprocess.check_output([sys.executable, "hb-downloader.py", a, "-h"])
 
 
 def test_parse_to_config():


### PR DESCRIPTION
currently, the test hardcodes and expects "python3" to be executable. This can break in two ways

- if python hasn't been added to the `%PATH%` or `$PATH` variable (not as important as this is against the default when installing python)
- if python doesn't have a `python3` executable. This is the big one for me. If you install python 3 from the default windows installer, it will install and set up `python` on your path, but python3 will fail with `[...]\lib\subprocess.py:1178: FileNotFoundError` and `[WinError 2]`

This patch replaces the string `python3` with sys.executable, which is "whatever python is running right now".