### PR TITLE
fixing wrong filename written to md5 hash file.

### DIFF
--- a/hb_downloader/humble_api/humble_hash.py
+++ b/hb_downloader/humble_api/humble_hash.py
@@ -154,7 +154,7 @@ class HumbleHash(object):
             return
 
         md5full_filename = HumbleHash.md5filename(full_filename)
-        local_filename = os.path.basename(md5full_filename)
+        local_filename = os.path.basename(full_filename)
 
         if os.path.exists(md5full_filename):
             os.remove(md5full_filename)


### PR DESCRIPTION
Currently, when md5 files are being written, they contain

```
9e777f886ce454ddc32c6ff3f3d99908 *startrek_thenextgeneration_thespacebetween.epub.md5
```

but this is wrong. The filename that's being referenced does not END in `.md5`. Only the hash file does. The correct naming would be:

```
9e777f886ce454ddc32c6ff3f3d99908 *startrek_thenextgeneration_thespacebetween.epub
```

This PR fixes it.