### PR TITLE
Fix wrong filename in read_md5file check

### DIFF
--- a/hb_downloader/humble_api/humble_hash.py
+++ b/hb_downloader/humble_api/humble_hash.py
@@ -119,7 +119,7 @@ class HumbleHash(object):
             return ""
 
         md5full_filename = HumbleHash.md5filename(full_filename)
-        local_filename = os.path.basename(md5full_filename)
+        local_filename = os.path.basename(full_filename)
 
         if not os.path.exists(md5full_filename):
             return ""


### PR DESCRIPTION
PR #14 removed the .md5 extension from the filename being written to
the md5 cache file by write_md5file. However, read_md5file was still
checking for the presence of the .md5 extension.

This makes read_md5file match write_md5file.