### PR TITLE
Add support for filtering files by size and extension

### DIFF
--- a/hb-downloader-settings.example.yaml
+++ b/hb-downloader-settings.example.yaml
@@ -7,6 +7,9 @@ write_md5: True
 read_md5: True
 debug: False
 get_extra_file_info: False
+# max file size in MB
+max-file-size: 1000
+
 
 default_headers:
   Accept: application/json
@@ -26,3 +29,9 @@ download-platforms:
   linux: True
   android: True
   asmjs: False
+
+# Only files with the following extensions are downloaded (or
+# everything when not configured):
+file-extensions:
+  - .mobi
+  - .pdf

--- a/hb_downloader/config_data.py
+++ b/hb_downloader/config_data.py
@@ -24,7 +24,9 @@ class ConfigData(object):
     download_product = "-not specified-"
     get_extra_file_info = False
     config_filename = "hb-downloader-settings.yaml"
-    
+    max_file_size = None
+    file_extensions = None
+
     download_platforms = {
         'audio': True,
         'ebook': True,

--- a/hb_downloader/configuration.py
+++ b/hb_downloader/configuration.py
@@ -77,6 +77,10 @@ class Configuration(object):
                 "ignore_md5", ConfigData.ignore_md5)
         ConfigData.get_extra_file_info = saved_config.get(
                 "get_extra_file_info", ConfigData.get_extra_file_info)
+        ConfigData.file_extensions = saved_config.get(
+                "file-extensions", ConfigData.file_extensions)
+        ConfigData.max_file_size = saved_config.get(
+                "max-file-size", ConfigData.max_file_size)
 
     @staticmethod
     def parse_command_line():
@@ -228,10 +232,20 @@ class Configuration(object):
                 True, "Config", "get_extra_file_info=%s" %
                 ConfigData.get_extra_file_info)
 
+        if ConfigData.max_file_size:
+            logger.display_message(
+                True, "Config", "max_file_size=%s" %
+                ConfigData.max_file_size)
+
         for platform in list(ConfigData.download_platforms.keys()):
             logger.display_message(
                     True, "Config", "Platform %s=%s" %
                     (platform, ConfigData.download_platforms[platform]))
+
+        if ConfigData.file_extensions:
+            logger.display_message(
+                True, "Config", "file_extensions=%s" %
+                ConfigData.file_extensions)
 
     @staticmethod
     def push_configuration():

--- a/hb_downloader/humble_download.py
+++ b/hb_downloader/humble_download.py
@@ -107,7 +107,7 @@ class HumbleDownload(object):
         """
 
         # TODO HK: add options for path structure from commandline and or cfg file
-        
+
         if not ConfigData.folderstructure_OrderName:
             temp_full_filename = os.path.join(
                 ConfigData.download_location,
@@ -118,7 +118,7 @@ class HumbleDownload(object):
                 ConfigData.download_location,
                 self.product_name_machine, self.subproduct_name, self.platform,
                 self.filename)
-        
+
         return temp_full_filename
 
     def remove(self):
@@ -221,7 +221,7 @@ class HumbleDownload(object):
         """ Creates the directory for storing the current file if it doesn't
             exist.
         """
-        
+
         # TODO HK: add options for path structure from commandline and or cfg file
 
         # full_directory = os.path.join(ConfigData.download_location,
@@ -307,9 +307,22 @@ class HumbleDownload(object):
                         current_download.platform, False):
                     continue
                 for current_dl_struct in current_download.download_structs:
-                    if "flac" in current_dl_struct.filename:
-                        print("no flacs: skipping: " + current_dl_struct.filename)
+                    # Check maximun file size
+                    if (ConfigData.max_file_size and
+                        current_dl_struct.file_size is not None and
+                        current_dl_struct.file_size / 1048576 > ConfigData.max_file_size):
                         continue
+
+                    # Check file extensions
+                    if ConfigData.file_extensions:
+                        fn_lower = current_dl_struct.filename.lower()
+                        ext_ok = False
+                        for ext in ConfigData.file_extensions:
+                            if fn_lower.endswith(ext.lower()):
+                                ext_ok = True
+                        if not ext_ok:
+                            continue
+
                     hd = HumbleDownload(current_download,
                                         current_dl_struct,
                                         current_order,


### PR DESCRIPTION
This pull request adds support for filtering the files that should be downloaded according to:
1) their file size, setting `max-file-size` in the configuration
2) the filename extensions (for instance `.pdf`), listing them in the configuration under the key `file-extensions`. When not given, all the file regardless of their extension are downloaded.