### PR TITLE
[docs] Fix typo in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ Perform one of the following actions:
 ## Installation
 After getting the installation files, you then need to fetch your
 authentication cookie from humblebundle.com.  To do so, navigate there, log in
-and press F12 to open the developper tools of your browser. Navigate to the
+and press F12 to open the developer tools of your browser. Navigate to the
 cookies tab, and look for a cookie named `_simpleauth_sess` (on the
 humblebundle.com domain). Copy the value inside the
 `hb-downloader-settings.yaml` file, or specify it on the command line with the


### PR DESCRIPTION
This fixes the README to fix a typo on the word "developer"